### PR TITLE
Implement decodeParams, and modify json middleware

### DIFF
--- a/examples/middleware.ts
+++ b/examples/middleware.ts
@@ -1,12 +1,20 @@
 // Copyright 2021 Riki Singh Khorana. All rights reserved. MIT license.
 
 import { Kyuko } from "../mod.ts";
+import { decodeParams } from "../middleware/decodeParams.ts";
 import { json, KyukoRequestWithJson } from "../middleware/json.ts";
 
 const app = new Kyuko();
 
-// Uses the `json` middleware
-app.use(json);
+app.use(decodeParams());
+app.use(json());
+
+/**
+ * Try accessing encoded url paths such as "/Alice%20%26%20Bob".
+ */
+app.get("/:name", (req, res) => {
+  res.send(`Hello ${req.params.name}!`);
+});
 
 /**
  * Responds with a pretty version of the JSON request body.

--- a/middleware/decodeParams.ts
+++ b/middleware/decodeParams.ts
@@ -1,0 +1,13 @@
+import { KyukoMiddleware, KyukoRequest } from "../mod.ts";
+
+/**
+ * Returns a `KyukoMiddleware` that decodes the values of `req.params`.
+ */
+export function decodeParams(): KyukoMiddleware {
+  return function (req: KyukoRequest) {
+    Object.keys(req.params).forEach((param) => {
+      const encoded = req.params[param];
+      req.params[param] = decodeURIComponent(encoded);
+    });
+  };
+}

--- a/middleware/json.ts
+++ b/middleware/json.ts
@@ -1,16 +1,32 @@
-import { KyukoRequest, KyukoResponse } from "../mod.ts";
+import { KyukoMiddleware, KyukoRequest } from "../mod.ts";
 
 export interface KyukoRequestWithJson extends KyukoRequest {
   // deno-lint-ignore no-explicit-any
   requestBody: any;
 }
 
-export async function json(req: KyukoRequest, res: KyukoResponse) {
-  const contentType = req.headers.get("content-type");
-  res.headers.append("Content-Type", "application/json; charset=utf-8");
-  if (contentType?.includes("application/json")) {
-    const requestClone = req.clone();
-    const json = await requestClone.json();
-    (req as KyukoRequestWithJson).requestBody = json;
-  }
+/**
+ * Returns a `KyukoMiddleware` that attempts to parse the request body as JSON.
+ * The parsed body is stored into `req.requestBody`.
+ * Note that `req.body` will be stay unused (hence `req.bodyUsed === false`).
+ *
+ * example:
+ *
+ * ```ts
+ * app.use(json());
+ *
+ * app.post("/", (req, res) => {
+ *   const { requestBody } = req as KyukoRequestWithJson;
+ * });
+ * ```
+ */
+export function json(): KyukoMiddleware {
+  return async function (req: KyukoRequest) {
+    const contentType = req.headers.get("content-type");
+    if (contentType?.includes("application/json")) {
+      const requestClone = req.clone();
+      const json = await requestClone.json();
+      (req as KyukoRequestWithJson).requestBody = json;
+    }
+  };
 }


### PR DESCRIPTION
Closes #7 

Turns out that query strings are encoded by default by `URLSearchParams`