### PR TITLE
Add custom error handlers

### DIFF
--- a/examples/errorHandling.ts
+++ b/examples/errorHandling.ts
@@ -12,7 +12,7 @@ app.error((err, _req, res) => {
 });
 
 app.get("/", (_req, _res) => {
-  throw new Error('An intentional error occurred!');
+  throw new Error("An intentional error occurred!");
 });
 
 app.listen();

--- a/examples/errorHandling.ts
+++ b/examples/errorHandling.ts
@@ -1,0 +1,18 @@
+// Copyright 2021 Riki Singh Khorana. All rights reserved. MIT license.
+
+import { Kyuko } from "../mod.ts";
+
+const app = new Kyuko();
+
+/**
+ * This will handle the error thrown.
+ */
+app.error((err, _req, res) => {
+  res.send(err.message);
+});
+
+app.get("/", (_req, _res) => {
+  throw new Error('An intentional error occurred!');
+});
+
+app.listen();

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,10 @@
 // Copyright 2021 Riki Singh Khorana. All rights reserved. MIT license.
 
 export { Kyuko } from "./src/Kyuko.ts";
-export type { KyukoMiddleware, KyukoRequestHandler } from "./src/Kyuko.ts";
+export type {
+  KyukoErrorHandler,
+  KyukoMiddleware,
+  KyukoRequestHandler,
+} from "./src/Kyuko.ts";
 export type { KyukoRequest } from "./src/KyukoRequest.ts";
 export type { KyukoResponse } from "./src/KyukoResponse.ts";


### PR DESCRIPTION
- Also change behavior of middleware execution - won't stop on `res.wasSent()`

Closes #11 